### PR TITLE
Prepending instead of appending default styles to <head>

### DIFF
--- a/src/remark.js
+++ b/src/remark.js
@@ -43,8 +43,13 @@
     style.type = 'text/css';
     style.innerHTML = '/* bundle "src/remark.css" */';
 
-    document.getElementsByTagName('head')[0].appendChild(style);
+    addElementToHead(style);
   };
+
+  var addElementToHead = function (element) {
+    var head = document.getElementsByTagName('head')[0];
+    head.insertBefore(element, head.firstChild);
+  }
 
   var createSlides = function () {
     var source = document.getElementById('source').innerHTML


### PR DESCRIPTION
I had a problem with Remark appending the default styles to `<head>`, as they were overwriting the styles I created in my own `slides.css` file, which I wanted in order to create a general design for my slideshows.

(Btw, it looks great so far! I'm absolutely going to test this on my next presentation!)
