### PR TITLE
Go to the next slide when pressing Space

### DIFF
--- a/src/remark.js
+++ b/src/remark.js
@@ -110,6 +110,7 @@
         case 75:
           gotoSlide(currentSlideIndex - 1);
           break;
+        case 32:
         case 39:
         case 40:
         case 74:


### PR DESCRIPTION
Often when I practice a presentation I end up using Space to go to the next slide in Keynote, would be nice to have the same behavior in Remark.
