### PR TITLE
Added touch events in order to support mobile phones

### DIFF
--- a/src/remark.js
+++ b/src/remark.js
@@ -18,6 +18,7 @@
     hideSource();
     createSlideshow();
     mapKeys();
+    mapTouches();
     navigate();
 
     window.onhashchange = navigate;
@@ -124,6 +125,27 @@
       }
     };
   };
+
+  var mapTouches = function () {
+    var width = window.innerWidth
+      , touch
+      ;
+
+    document.addEventListener('touchend', function (event) {
+      touch = event.changedTouches[0];
+
+      if (touch.clientX < width / 2) {
+        gotoSlide(currentSlideIndex - 1);
+      }
+      else {
+        gotoSlide(currentSlideIndex + 1);
+      }
+    });
+
+    document.addEventListener('touchmove', function (event) {
+      event.preventDefault();
+    });
+  }
 
   var gotoSlide = function (slideIndex) {
     var alreadyOnSlide = slideIndex === currentSlideIndex


### PR DESCRIPTION
Very simple support for touch events so Remark can be used on mobile
phones. There is a slew of unanswered questions, including how pinching
and double-clicking to zoom works. This patch only solves the very, very
basic problem of getting to the previous (touching the left half of the
slide) and next slide (toucing the right half of the slide).

(Only tested on iPhone)
