### PR TITLE
Fixed non-working resize

### DIFF
--- a/src/remark/slideshow.js
+++ b/src/remark/slideshow.js
@@ -49,14 +49,15 @@
   };
 
   var styleElement = function (element) {
-    var containerHeight = window.innerHeight
-      , containerWidth = window.innerWidth
-      , elementWidth = scaleFactor * widthFactor
+    var elementWidth = scaleFactor * widthFactor
       , elementHeight = scaleFactor * heightFactor
       ;
 
     var resize = function () {
-      var scale;
+      var containerHeight = window.innerHeight
+        , containerWidth = window.innerWidth
+        , scale
+        ;
 
       if (containerWidth / widthFactor > containerHeight / heightFactor) {
         scale = containerHeight / (scaleFactor * heightFactor);


### PR DESCRIPTION
Because the innerHeight and innerWidth was fetched only at setup the
slideshow would not resize when onresize was triggered. Now it should
work as it did before the refactoring.
