### PR TITLE
Add failing test for converting several classes on a single line

### DIFF
--- a/spec/remark/converterSpec.js
+++ b/spec/remark/converterSpec.js
@@ -68,6 +68,11 @@ describe('converter', function () {
         .toBe('<span class="class">text</span>')
     });
 
+    it('should convert several classes', function () {
+      expect(convert('.class[text] and .class2[text]'))
+        .toBe('<span class="class">text</span> and <span class="class2">text</span>')
+    });
+
     it('should convert multiple classes', function () {
       expect(convert('.a.b.c[text]'))
         .toBe('<span class="a b c">text</span>');
@@ -92,7 +97,7 @@ describe('converter', function () {
 
       source.innerHTML = text;
       content.innerHTML = source.innerHTML;
-      remark.converter.convertMarkdown(content) 
+      remark.converter.convertMarkdown(content)
       return content.innerHTML;
     };
 


### PR DESCRIPTION
This is just a failing test, and I have not tried to solve the problem. The problem is not easily solved through a regexp as remark is supposed to handle Markdown syntax for images, and handling matching parentheses through regexp ... well, it ain't easy.

I don't know if this functionality is necessary. However, I wanted this functionality in a slide I created, so I thought maybe someone else also might want it too.
