### PR TITLE
Initial event support

### DIFF
--- a/src/remark.js
+++ b/src/remark.js
@@ -6,8 +6,11 @@
   /* bundle "src/remark/dispatcher.js" */
   /* bundle "src/remark/highlighter.js" */
   /* bundle "src/remark/slideshow.js" */
+  /* bundle "vendor/EventEmitter.min.js" */
 
   var remark = context.remark = context.remark || {};
+
+  remark.events = new EventEmitter();
 
   window.onload = function () {
     var sourceElement = document.getElementById('source')

--- a/src/remark/slideshow.js
+++ b/src/remark/slideshow.js
@@ -16,6 +16,7 @@
       showSlide: function (slideIndex) {
         var slide = element.children[slideIndex];
         prepareSlideIfNeeded(slide, slides, slideIndex);
+        remark.events.emit('slidein', slide, slideIndex);
         slide.style.display = 'table';
       }
     , hideSlide: function (slideIndex) {

--- a/vendor/EventEmitter.min.js
+++ b/vendor/EventEmitter.min.js
@@ -1,0 +1,11 @@
+/*
+ EventEmitter v3.1.0
+ https://github.com/Wolfy87/EventEmitter
+
+ Licenced under GPL v3 http://www.gnu.org/licenses/gpl.html
+ Oliver Caldwell (olivercaldwell.co.uk)
+*/
+(function(h){function b(){this._events={};this._maxListeners=10}function g(a,e,c,d,b){this.type=a;this.listener=e;this.scope=c;this.once=d;this.instance=b}g.prototype.fire=function(a){this.listener.apply(this.scope||this,a);if(this.once)return this.instance.removeListener(this.type,this.listener),!1};b.prototype.eachListener=function(a,e){var c=null,b=null,f=null;if(this._events.hasOwnProperty(a)){b=this._events[a];for(c=0;c<b.length;c+=1)if(f=e.call(this,b[c],c),f===!1)c-=1;else if(f===!0)break}return this};
+b.prototype.addListener=function(a,b,c,d){this._events.hasOwnProperty(a)||(this._events[a]=[]);this._events[a].push(new g(a,b,c,d,this));this.emit("newListener",a,b,c,d);if(this._maxListeners&&!this._events[a].warned&&this._events[a].length>this._maxListeners)typeof console!=="undefined"&&console.warn("Possible EventEmitter memory leak detected. "+this._events[a].length+" listeners added. Use emitter.setMaxListeners() to increase limit."),this._events[a].warned=!0;return this};b.prototype.on=b.prototype.addListener;
+b.prototype.once=function(a,b,c){return this.addListener(a,b,c,!0)};b.prototype.removeListener=function(a,b){this.eachListener(a,function(c,d){c.listener===b&&this._events[a].splice(d,1)});this._events[a]&&this._events[a].length===0&&delete this._events[a];return this};b.prototype.removeAllListeners=function(a){if(a&&this._events.hasOwnProperty(a))delete this._events[a];else if(!a)this._events={};return this};b.prototype.listeners=function(a){if(this._events.hasOwnProperty(a)){var b=[];this.eachListener(a,
+function(a){b.push(a.listener)});return b}return[]};b.prototype.emit=function(a){for(var b=[],c=null,c=1;c<arguments.length;c+=1)b.push(arguments[c]);this.eachListener(a,function(a){return a.fire(b)});return this};b.prototype.setMaxListeners=function(a){this._maxListeners=a;return this};h.EventEmitter=b})(this);


### PR DESCRIPTION
I needed an event to fire when slides where shown, so I implemented a simple event support. Here's an example of using this support:

```
  var remark = this.remark;
  $(document).ready(function() {
    remark.events.addListener("slide", function() {
      // do JavaScript stuff that relates to the slide
    });
  });
```

This can be extended throughout remark, so a lot of cool stuff can be done in JS when presenting. What I'm using it for right now is looking for a `code` tag with a `coffeescript` class on the slide, and enable running the CoffeeScript right there (making a presentation on CoffeeScript and SASS).
