### PR TITLE
Make the syntax highlighting engine available from the outside

### DIFF
--- a/src/remark/highlighter.js
+++ b/src/remark/highlighter.js
@@ -37,6 +37,10 @@
     return styles[config.highlightStyle];
   };
 
+  highlighter.engine = function() {
+    return hljs;
+  };
+
   highlighter.highlightCodeBlocks = function (content) {
     var codeBlocks = content.getElementsByTagName('code')
       , block


### PR DESCRIPTION
The specific reason I needed this was to extend the current highlighting engine with syntax for a new language (for my [presentation on CoffeeScript](http://kjbekkelund.github.com/nith-coffeescript/))
