### PR TITLE
Change slide on event instead of via controller

### DIFF
--- a/src/remark.js
+++ b/src/remark.js
@@ -56,13 +56,11 @@
   var setupSlideshow = function (sourceElement, slideshowElement) {
     var source = sourceElement.innerHTML
       , slideshow
-      , controller
-      , dispatcher
       ;
 
     slideshow = remark.slideshow.create(source, slideshowElement);
-    controller = remark.controller.create(slideshow);
-    dispatcher = remark.dispatcher.create(controller);
+    remark.controller.create(slideshow);
+    remark.dispatcher.create();
   };
 
 }(this);

--- a/src/remark/controller.js
+++ b/src/remark/controller.js
@@ -13,15 +13,14 @@
 
     window.onhashchange = navigate;
     navigate();
-    
-    return {
-      gotoPreviousSlide: function () {
-        gotoSlide(slideshow, currentSlideIndex - 1);
-      }
-    , gotoNextSlide: function () {
-        gotoSlide(slideshow, currentSlideIndex + 1);
-      }
-    };
+
+    remark.events.on('previousSlide', function() {
+      gotoSlide(slideshow, currentSlideIndex - 1);
+    });
+
+    remark.events.on('nextSlide', function() {
+      gotoSlide(slideshow, currentSlideIndex + 1);
+    });
   };
 
   var gotoSlide = function (slideshow, slideIndex) {

--- a/src/remark/dispatcher.js
+++ b/src/remark/dispatcher.js
@@ -4,37 +4,37 @@
     , dispatcher = remark.dispatcher = {}
     ;
 
-  dispatcher.create = function (controller) {
-    mapKeys(controller);
-    mapTouches(controller);
-    mapWheel(controller);
+  dispatcher.create = function () {
+    mapKeys();
+    mapTouches();
+    mapWheel();
 
     return {
 
     };
   };
 
-  var mapKeys = function (controller) {
+  var mapKeys = function () {
     window.onkeydown = function (event) {
       switch (event.keyCode) {
         case 33:
         case 37:
         case 38:
         case 75:
-          controller.gotoPreviousSlide();
+          remark.events.emit('previousSlide');
           break;
         case 32:
         case 34:
         case 39:
         case 40:
         case 74:
-          controller.gotoNextSlide();
+          remark.events.emit('nextSlide');
           break;
       }
     };
   };
 
-  var mapTouches = function (controller) {
+  var mapTouches = function () {
     var width = window.innerWidth
       , touch
       , startX
@@ -47,19 +47,19 @@
 
     var handleTap = function () {
       if (endX < width / 2) {
-        controller.gotoPreviousSlide();
+        remark.events.emit('previousSlide');
       }
       else {
-        controller.gotoNextSlide();
+        remark.events.emit('nextSlide');
       }
     };
 
     var handleSwipe = function () {
       if (startX > endX) {
-        controller.gotoNextSlide();
+        remark.events.emit('nextSlide');
       }
       else {
-        controller.gotoPreviousSlide();
+        remark.events.emit('previousSlide');
       }
     };
 
@@ -89,13 +89,13 @@
     });
   };
 
-  var mapWheel = function (controller) {
+  var mapWheel = function () {
     document.addEventListener('mousewheel', function (event) {
       if (event.wheelDeltaY > 0) {
-        controller.gotoPreviousSlide();
+        remark.events.emit('previousSlide');
       }
       else if (event.wheelDeltaY < 0) {
-        controller.gotoNextSlide();
+        remark.events.emit('nextSlide');
       };
     });
   };


### PR DESCRIPTION
I see two sweet wins with this way of tackling the problem:
- It's far easier for others to tap into changing slides through the same "interface" as they can get slides that are sliding in and out, thus it makes remark more extendable.
- We don't have to send the `controller` around internally.

However, I was not sure about the name of the events.

Your thoughts?
