### PR TITLE
Change src for script tags hotlinking remark from using .com to .io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Below is a boilerplate HTML file to get you started:
   <head>
     <title>Title</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <script src="http://gnab.github.com/remark/downloads/remark-0.4.6.min.js" type="text/javascript">
+    <script src="http://gnab.github.io/remark/downloads/remark-0.4.6.min.js" type="text/javascript">
     </script>
     <style type="text/css" media="screen">
       /* Slideshow styles */


### PR DESCRIPTION
Chrome displays insecure content warning and blocks loading remark when the slideshow is served from another gh-pages page on github, as github has started redirecting from e.g. `somepage.github.com` to `somepage.github.io`.
