### PR TITLE
Fix github link in example HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class: center, middle
 # Introduction
 
     </textarea>
-    <script src="http://gnab.github.com/remark/downloads/remark-0.5.3.min.js" type="text/javascript">
+    <script src="http://gnab.github.io/remark/downloads/remark-0.5.3.min.js" type="text/javascript">
     </script>
     <script type="text/javascript">
       var slideshow = remark.create();


### PR DESCRIPTION
Github websites accessed via *.github.com now return a 301: moved permanently to the github.io domain.
