### PR TITLE
Turn help screen's background black.

### DIFF
--- a/src/remark.less
+++ b/src/remark.less
@@ -231,6 +231,7 @@ html.remark-container, body.remark-container {
 .remark-container.remark-help-mode {
   .remark-help {
     display: block;
+	background: black;
   }
   .remark-backdrop {
     display: block;


### PR DESCRIPTION
In the default configuration (from the example in README; slides with
white background), the help screen is not visible clearly. Setting the
background to black allows the help to be read clearly.

Note: I am not including the generated files in the commit, to keep the
patch small.
