### PR TITLE
Introduce 3 types of boilerplate HTML files, to get a new person started.

### DIFF
--- a/boilerplate-local.html
+++ b/boilerplate-local.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Awesome Presentation</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style type="text/css">
+      /* Slideshow styles */
+    </style>
+  </head>
+  <body>
+    <textarea id="source">
+
+class: center, middle
+
+# My Awesome Presentation
+
+---
+
+# Agenda
+
+1. Introduction
+2. Deep-dive
+3. ...
+
+[NOTE]: Note that you need remark.js alongside this html file, but no internet connection.
+---
+
+# Introduction
+
+    </textarea>
+    <script src="remark.js" type="text/javascript">
+    </script>
+    <script type="text/javascript">
+      var slideshow = remark.create();
+    </script>
+  </body>
+</html>

--- a/boilerplate-remote.html
+++ b/boilerplate-remote.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Awesome Presentation</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style type="text/css">
+      /* Slideshow styles */
+    </style>
+  </head>
+  <body>
+    <textarea id="source">
+
+class: center, middle
+
+# My Awesome Presentation
+
+---
+
+# Agenda
+
+1. Introduction
+2. Deep-dive
+3. ...
+
+[NOTE]: Note that you need active internet connection to access remark.js script file
+---
+
+# Introduction
+
+    </textarea>
+    <script src="http://gnab.github.io/remark/downloads/remark-0.6.0.min.js" type="text/javascript">
+    </script>
+    <script type="text/javascript">
+      var slideshow = remark.create();
+    </script>
+  </body>
+</html>

--- a/make.js
+++ b/make.js
@@ -8,6 +8,7 @@ target.all = function () {
   target.test();
   target.bundle();
   target.minify();
+  target.boilerplate();
 };
 
 target.highlighter = function () {
@@ -29,6 +30,11 @@ target.bundle = function () {
   console.log('Bundling...');
   bundleResources('src/remark/resources.js');
   run('browserify src/remark.js', {silent: true}).output.to('remark.js');
+};
+
+target.boilerplate = function () {
+  console.log('Generating boilerplate...');
+  generateBoilerplateSingle("boilerplate-single.html");
 };
 
 target.minify = function () {
@@ -73,6 +79,21 @@ function bundleHighlighter (target) {
       };
 
   cat('src/highlighter.js.template')
+    .replace(/%(\w+)%/g, function (match, key) {
+      return resources[key];
+    })
+    .to(target);
+}
+
+function generateBoilerplateSingle(target) {
+  var resources = {
+        REMARK_MINJS: escape(cat('remark.min.js')
+                              // highlighter has a ending script tag as a string literal, and
+                              // that causes early termination of escaped script. Split that literal.
+                              .replace('"</script>"', '"</" + "script>"'))
+      };
+
+  cat('src/boilerplate-single.html.template')
     .replace(/%(\w+)%/g, function (match, key) {
       return resources[key];
     })

--- a/src/boilerplate-single.html.template
+++ b/src/boilerplate-single.html.template
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Awesome Presentation</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <style type="text/css">
+      /* Slideshow styles */
+    </style>
+  </head>
+  <body onload="var slideshow = remark.create();">
+    <textarea id="source">
+
+class: center, middle
+
+# My Awesome Presentation
+
+---
+
+# Agenda
+
+1. Introduction
+2. Deep-dive
+3. ...
+
+[NOTE]: This file is portable; you don't need any other file, or an internet connection for this presentation.
+---
+
+# Introduction
+
+    </textarea>
+    <script type="text/javascript">
+      document.write(unescape("%3Cscript type='text/javascript'%3E" + "%REMARK_MINJS%" + "%3C/script%3E"));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This commit is primarily to reduce barrier to entry; just ask people to
start off with one of these boilerplate HTML files, and they should be
content with the results.

boilerplate-single.html (generated from a template) is a standalone file
that can be used on an offline computer, and without a need of any other
file, like remark.js, etc.

boilerplate-local.html can be used by people who want to present without
an internet connection. This requires at least the accompanying
remark.js file for the presentations to work.

boilerplate-remote.html is for presenting in environments where internet
connectivity is available, and no other accompanying file is needed for
the presntation to work.

Note: I am not including the generated files in the commit, to keep the
patch small.
