### PR TITLE
add bower integration

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "remark",
+  "version": "0.6.0",
+  "homepage": "http://remarkjs.com/",
+  "authors": [
+    "Ole Petter Bang <olepbang@gmail.com>"
+  ],
+  "description": "A simple, in-browser, markdown-driven slideshow tool.",
+  "main": "out/remark.js",
+  "keywords": [
+    "Markdown",
+    "Slides"
+  ],
+  "license": "MIT",
+  "ignore": [
+    ".gitignore",
+    ".gitmodules",
+    ".jshintignore",
+    ".jshintrc",
+    "HISTORY.md",
+    "LICENCE",
+    "make.js",
+    "Makefile",
+    "package.json",
+    "bower_components",
+    "node_modules",
+    "src",
+    "test",
+    "vendor"
+  ]
+}


### PR DESCRIPTION
I wrote down a simple bower.json because I'd like for remark to be available as a bower module.

I don't dare registering it on my own, so I wasn't able to test it :smile: 
