### PR TITLE
Ignore keydown with meta and ctrl modifiers

### DIFF
--- a/src/remark/controllers/inputs/keyboard.js
+++ b/src/remark/controllers/inputs/keyboard.js
@@ -8,6 +8,11 @@ exports.unregister = function (events) {
 
 function addKeyboardEventListeners (events) {
   events.on('keydown', function (event) {
+    if (event.metaKey || event.ctrlKey) {
+      // Bail out if meta or ctrl key was pressed
+      return;
+    }
+
     switch (event.keyCode) {
       case 33: // Page up
       case 37: // Left


### PR DESCRIPTION
This prevents ctrl-pagedown, which moves a tab in Chrome, from also
advancing the slide.
