### PR TITLE
Remarkise now extracts CSS (<style> nodes) from the original markdown document and puts them on the generated HTML page instead

### DIFF
--- a/remarkise.html
+++ b/remarkise.html
@@ -108,11 +108,16 @@
               [/\/\/raw\.githubusercontent\.com\//, '//rawgit.com/']
             ]
           }
-        ];
+        ]
+        ,   CSS = /<style[^>]*>[^<]*<\/style>/ig
+        ;
 
         var nextFix = 0
-          , currentFix
-          , newUrl;
+        ,   currentFix
+        ,   newUrl
+        ,   css
+        ,   i
+        ;
 
         function remarkise(url) {
 
@@ -147,6 +152,13 @@
               }
 
               $('div#front-page').hide();
+              css = data.match(CSS);
+              if (css) {
+                  data = data.replace(CSS, '');
+                  for (i in css) {
+                      $('head').append(css[i]);
+                  }
+              }
               remark.create({source: data});
             }
           });


### PR DESCRIPTION
Solves issue #169.
