### PR TITLE
Add live reloading (via Grunt)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,40 @@
+/* global module:false */
+module.exports = function(grunt) {
+  var port = grunt.option('port') || 8000;
+  // Project configuration
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    connect: {
+      server: {
+        options: {
+          port: port,
+          base: '.',
+          livereload: true,
+          open: {
+            target: 'http://localhost:' + port + '/boilerplate-local.html'
+          },
+        }
+      }
+    },
+    watch: {
+      options: {
+        livereload: true
+      },
+      js: {
+        files: [ 'Gruntfile.js', 'out/remark.js', 'out/remark.min.js' ]
+      },
+      html: {
+        files: [ '*.html']
+      }
+    }
+
+  });
+
+  // Dependencies
+  grunt.loadNpmTasks( 'grunt-contrib-watch' );
+  grunt.loadNpmTasks( 'grunt-contrib-connect' );
+
+  // Serve presentation locally
+  grunt.registerTask( 'serve', [ 'connect', 'watch' ] );
+
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   , "sinon": "1.8.2"
   , "jshint": "2.1.2"
   , "shelljs": "0.1.4"
+  , "grunt-contrib-watch": "~0.5.3"
+  , "grunt-contrib-connect": "~0.8.0"
+  , "grunt": "~0.4.0"
   }
 , "scripts": {
     "test": "node make test"


### PR DESCRIPTION
Adds live reloading using `grunt-contrib-watch`.

To use, enter `grunt serve` (default port: 8000) or specify the port using `grunt serve --port 8765`.