### PR TITLE
Clean up HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta charset="utf-8" />
     <meta name="keywords" content="remark,remarkjs,markdown,slideshow,presentation" />
     <meta name="description" content="A simple, in-browser, markdown-driven slideshow tool." />
     <title>Remark</title>
-    <style type="text/css">
-      @import url(//fonts.googleapis.com/css?family=Droid+Serif);
-      @import url(//fonts.googleapis.com/css?family=Yanone+Kaffeesatz);
-      @import url(//fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
+    <style>
+      @import url(https://fonts.googleapis.com/css?family=Droid+Serif);
+      @import url(https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz);
+      @import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
 
       body {
         font-family: 'Droid Serif';
@@ -33,8 +33,6 @@
         text-decoration: none;
       }
       code {
-        -moz-border-radius: 5px;
-        -web-border-radius: 5px;
         background: #e7e8e2;
         border-radius: 5px;
       }
@@ -258,9 +256,9 @@ A simple HTML document is needed for hosting the styles, Markdown and the genera
 *    <textarea id="source">
       <!-- Slideshow Markdown -->
     &lt;/textarea&gt;
-*    <script type="text/javascript" src="remark.js">
+*    <script src="remark.js">
     </script>
-    <script type="text/javascript">
+    <script>
 *      var slideshow = remark.create();
     </script>
   </body>
@@ -461,27 +459,28 @@ template: inverse
 
 Slideshow created using [remark](http://github.com/gnab/remark).
     </textarea>
-    <script src="downloads/remark-latest.min.js" type="text/javascript"></script>
-    <script type="text/javascript">
+    <script src="downloads/remark-latest.min.js"></script>
+    <script>
       var hljs = remark.highlighter.engine;
     </script>
-    <script src="remark.language.js" type="text/javascript"></script>
-    <script type="text/javascript">
+    <script src="remark.language.js"></script>
+    <script>
       var slideshow = remark.create({
           highlightStyle: 'monokai',
           highlightLanguage: 'remark'
         }) ;
     </script>
-    <script type="text/javascript">
+    <script>
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-44561333-1']);
       _gaq.push(['_trackPageview']);
 
       (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
+        var ga = document.createElement('script');
+        ga.src = 'https://ssl.google-analytics.com/ga.js';
+        var s = document.scripts[0];
+        s.parentNode.insertBefore(ga, s);
+      }());
     </script>
   </body>
 </html>


### PR DESCRIPTION
Remove redundant attribute/value pairs, etc. This simplifies the “installation” instructions, too!