### PR TITLE
Attempt to allow disabling code line highlighting

### DIFF
--- a/src/remark/models/slideshow.js
+++ b/src/remark/models/slideshow.js
@@ -38,6 +38,7 @@ function Slideshow (events, options) {
 
   self.getRatio = getOrDefault('ratio', '4:3');
   self.getHighlightStyle = getOrDefault('highlightStyle', 'default');
+  self.getHighlightLines = getOrDefault('highlightLines', true);
   self.getHighlightLanguage = getOrDefault('highlightLanguage', '');
   self.getSlideNumberFormat = getOrDefault('slideNumberFormat', '%current% / %total%');
 

--- a/src/remark/views/slideView.js
+++ b/src/remark/views/slideView.js
@@ -193,10 +193,12 @@ function setClassFromProperties (element, properties) {
 }
 
 function highlightCodeBlocks (content, slideshow) {
-  var codeBlocks = content.getElementsByTagName('code')
-    ;
+  var codeBlocks = content.getElementsByTagName('code');
+  var highlightLines = slideshow.getHighlightLines();
 
   codeBlocks.forEach(function (block) {
+    var meta;
+
     if (block.parentElement.tagName !== 'PRE') {
       utils.addClass(block, 'remark-inline-code');
       return;
@@ -206,14 +208,20 @@ function highlightCodeBlocks (content, slideshow) {
       block.className = slideshow.getHighlightLanguage();
     }
 
-    var meta = extractMetadata(block);
+    if (highlightLines) {
+      meta = extractMetadata(block);
+    }
 
     if (block.className !== '') {
       highlighter.engine.highlightBlock(block, '  ');
     }
 
     wrapLines(block);
-    highlightBlockLines(block, meta.highlightedLines);
+
+    if (highlightLines) {
+      highlightBlockLines(block, meta.highlightedLines);
+    }
+
     highlightBlockSpans(block);
 
     utils.addClass(block, 'remark-code');


### PR DESCRIPTION
This is my attempt to allow code line highlighting to be disabled, in the following fashion:

```
    <script type="text/javascript">
      var slideshow = remark.create({
        highlightLines: false;
      });
    </script>
```

This fix is missing something, it causes tests to fail. But, this is my first experience with Javascript, so I am not sure if this is a correct method and would appreciate assistance getting this implemented.
