### PR TITLE
Remark properties into HTML comment

### DIFF
--- a/src/remark/parser.js
+++ b/src/remark/parser.js
@@ -169,7 +169,7 @@ function appendTo (element, content) {
 }
 
 function extractProperties (source, properties) {
-  var propertyFinder = /^\n*([-\w]+):([^$\n]*)/i
+  var propertyFinder = /^(?:\n*([-\w]+):([^$\n]*)|\n*<!--\s*([-\w]+):([^$\n]*)\s*-->)/i
     , match
     ;
 
@@ -177,7 +177,7 @@ function extractProperties (source, properties) {
     source = source.substr(0, match.index) +
       source.substr(match.index + match[0].length);
 
-    properties[match[1].trim()] = match[2].trim();
+    properties[(match[1] || match[3]).trim()] = (match[2] || match[4]).trim();
 
     propertyFinder.lastIndex = match.index;
   }


### PR DESCRIPTION
Proof of concept implementation, definitely not clean one. In that way, properties won't be visible when reading the markdown file using e.g. GitHub web interface, so that it is cleaner for reading.

It is possible to put each property in comment, so that instead:
```
class: middle, center
```
you can write
```
<!-- class: center, middle -->
```
Each property needs to have it's own comment for my implementation.

Any ideas how to improve?
