### PR TITLE
Allow uppercase letters to send toggles.

### DIFF
--- a/src/remark/controllers/inputs/keyboard.js
+++ b/src/remark/controllers/inputs/keyboard.js
@@ -43,7 +43,7 @@ function addKeyboardEventListeners (events) {
       return;
     }
 
-    switch (String.fromCharCode(event.which)) {
+    switch (String.fromCharCode(event.which).toLowerCase()) {
       case 'j':
         events.emit('gotoNextSlide');
         break;


### PR DESCRIPTION
The slideshow containing the docs says pushing "P" will toggle presenter mode. This is in fact only true when you push "p", so without shift. This fix makes sure both "P" and "p" are correct. This will cause less confusion.