### PR TITLE
Silence build tools to prevent garbage output

### DIFF
--- a/make.js
+++ b/make.js
@@ -85,7 +85,7 @@ target.boilerplate = function () {
 
 target.minify = function () {
   console.log('Minifying...');
-  run('uglifyjs out/remark.js', {silent: true}).output.to('out/remark.min.js');
+  run('uglifyjs -m -c -o out/remark.min.js out/remark.js', {silent: true});
 };
 
 target.deploy = function () {
@@ -189,7 +189,7 @@ function mapStyle (map, file) {
 }
 
 function less (file) {
-  return run('lessc -x ' + file, {silent: true}).output.replace(/\n/g, '');
+  return run('lessc -x -s ' + file, {silent: true}).output.replace(/\n/g, '');
 }
 
 function git (cmd) {

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
 , "devDependencies": {
     "browserify": "2.14.2"
   , "uglify-js": "2.3.5"
-  , "less": "1.3.3"
+  , "less": "~2.5"
   , "mocha": "1.17.0"
   , "mocha-phantomjs": "3.3.1"
   , "phantomjs": "1.9.2-6"
   , "should": "1.2.2"
   , "sinon": "1.8.2"
-  , "jshint": "2.1.2"
-  , "shelljs": "0.1.4"
+  , "jshint": "~2.7"
+  , "shelljs": "~0.4"
   }
 , "scripts": {
     "test": "node make test"


### PR DESCRIPTION
When using shelljs' exec function, the stdout output of the executed
process is mangled with the stderr output.

This causes deprecation warnings like `util.print: Use console.log
instead` to appear e.g. in out/remark.min.js when using an up-to-date
nodejs binary (v0.12.2) after running `node make minify`.

Using the `-o` output file option solved this problem easily because
it circumventes the broken shelljs output handling.

The same problem arises when running the less compiler.

Trying to upgrade the less compiler to the latest version did remove
the warning, in exchange for a new one:

```
The compress option has been deprecated. We recommend you use a
dedicated css minifier, for instance see less-plugin-clean-css.html
```

This message appeared in the generated `src/remark/resources.js` file
after running `node make bundle`.

That's easy to remedy by using the `--silence` option.

Fixes #226