### PR TITLE
Use black background for container

### DIFF
--- a/src/remark.less
+++ b/src/remark.less
@@ -8,7 +8,7 @@ html.remark-container, body.remark-container {
   -webkit-print-color-adjust: exact;
 }
 .remark-container {
-  background: #d7d8d2;
+  background: #000;
   margin: 0;
   overflow: hidden;
 }

--- a/src/remark.less
+++ b/src/remark.less
@@ -44,9 +44,6 @@ html.remark-container, body.remark-container {
   -webkit-transform-origin: top left;
   -moz-transform-origin: top left;
   transform-origin: top-left;
-  -moz-box-shadow: 0 0 30px #888;
-  -webkit-box-shadow: 0 0 30px #888;
-  box-shadow: 0 0 30px #888;
 }
 .remark-slide {
   height: 100%;


### PR DESCRIPTION
First, let me say that I have been a long time hater of HTML-based presentations. But I recently used remark for my [OSCON talk](http://opensoul.org/99ways/) and _loved_ it! Excellent work!

When presenting on a projector that doesn't match the aspect ratio of the slides, remark currently has a grey background, which makes it obvious to the audience that there is a mismatch. By using a black background, it is completely unnoticeable to the audience.

## Before

<img width="1279" alt="my_awesome_presentation_and_remark_ _brandon_bkeepers____projects_remark_ _zsh_ _80x24" src="https://cloud.githubusercontent.com/assets/173/8922432/a32129e6-3497-11e5-8d9c-997e2e1345d9.png">

## After

<img width="1279" alt="my_awesome_presentation_and_remark_less_-__users_brandon_projects_remark_-_atom" src="https://cloud.githubusercontent.com/assets/173/8922404/4bbe430a-3497-11e5-988f-50e3ad834e38.png">
