### PR TITLE
Increase contrast of presenter notes

### DIFF
--- a/src/remark.less
+++ b/src/remark.less
@@ -288,7 +288,7 @@ html.remark-container, body.remark-container {
 }
 
 .remark-notes-area {
-  background: #e7e8e2;
+  background: #fff;
   bottom: 0;
   color: black;
   display: none;
@@ -317,13 +317,10 @@ html.remark-container, body.remark-container {
       display: block;
       text-decoration: none;
       font-family: Helvetica,arial,freesans,clean,sans-serif;
-      border-bottom: 1px solid #ccc;
       height: 21px;
       font-size: 0.75em;
-      font-weight: bold;
       text-transform: uppercase;
-      color: #666;
-      text-shadow: #f5f5f5 1px 1px 1px;
+      color: #ccc;
     }
 
     .remark-notes-current-area {
@@ -340,6 +337,7 @@ html.remark-container, body.remark-container {
         right: 0px;
         overflow-y: auto;
         margin-bottom: 20px;
+        padding-top: 10px;
       }
     }
 


### PR DESCRIPTION
The presenter mode for remark is better than anything I've ever used (even Keynote). I love having the slides stacked on one side and the notes on the other.

However, I found the notes a little difficult to read. This increases the contrast by making the background white, and lightening the elements labels that are fixed. What do you think?

## Before

<img width="1275" alt="my_awesome_presentation" src="https://cloud.githubusercontent.com/assets/173/8922544/2222d400-3499-11e5-90d3-7db84e0de79e.png">

## After

<img width="1279" src="https://cloud.githubusercontent.com/assets/173/8922530/03888882-3499-11e5-8488-e5ae0c51c3ab.png">