### PR TITLE
Remark on IE 10&11 and Microsoft Edge

### DIFF
--- a/src/remark.less
+++ b/src/remark.less
@@ -16,10 +16,25 @@ html.remark-container, body.remark-container {
   outline-style: solid;
   outline-width: 1px;
 }
+
 :-webkit-full-screen .remark-container {
   width: 100%;
   height: 100%;
 }
+:-moz-full-screen .remark-container {
+  width: 100%;
+  height: 100%;
+}
+:-ms-fullscreen .remark-container {
+  width: 100%;
+  height: 100%;
+}
+:fullscreen .remark-container {
+  width: 100%;
+  height: 100%;
+}
+
+
 
 /**********/
 /* Slides */
@@ -43,9 +58,13 @@ html.remark-container, body.remark-container {
   position: absolute;
   -webkit-transform-origin: top left;
   -moz-transform-origin: top left;
+  -ms-transform-origin: top left;
+  -o-transform-origin: top left;
   transform-origin: top-left;
-  -moz-box-shadow: 0 0 30px #888;
   -webkit-box-shadow: 0 0 30px #888;
+  -moz-box-shadow: 0 0 30px #888;
+  -ms-box-shadow: 0 0 30px #888;
+  -o-box-shadow: 0 0 30px #888;
   box-shadow: 0 0 30px #888;
 }
 .remark-slide {
@@ -142,8 +161,10 @@ html.remark-container, body.remark-container {
   display: block;
   z-index: 1;
   .remark-slide-scaler {
-    -moz-box-shadow: none;
     -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    -ms-box-shadow: none;
+    -o-box-shadow: none;
     box-shadow: none;
   }
 }
@@ -217,6 +238,8 @@ html.remark-container, body.remark-container {
   z-index: 1000;
   -webkit-transform-origin: top left;
   -moz-transform-origin: top left;
+  -ms-transform-origin: top left;
+  -o-transform-origin: top left;
   transform-origin: top-left;
 
   .remark-help-content {
@@ -440,6 +463,7 @@ html.remark-container, body.remark-container {
     -moz-transform: scaleX(-1);
     -ms-transform: scaleX(-1);
     -o-transform: scaleX(-1);
+    transform: scaleX(-1);
   }
 }
 
@@ -478,8 +502,10 @@ html.remark-container, body.remark-container {
     position: relative;
   }
   .remark-slide-scaler {
-    -moz-box-shadow: none;
     -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    -ms-box-shadow: none;
+    -o-box-shadow: none;
     box-shadow: none;
   }
 }

--- a/src/remark/scaler.js
+++ b/src/remark/scaler.js
@@ -50,6 +50,9 @@ Scaler.prototype.scaleToFit = function (element, container) {
 
   element.style['-webkit-transform'] = 'scale(' + scale + ')';
   element.style.MozTransform = 'scale(' + scale + ')';
+  element.style['-ms-transform'] = 'scale(' + scale + ')';
+  element.style['-o-transform'] = 'scale(' + scale + ')';
+  element.style.transform = 'scale(' + scale + ')';
   element.style.left = Math.max(left, 0) + 'px';
   element.style.top = Math.max(top, 0) + 'px';
 };

--- a/src/remark/utils.js
+++ b/src/remark/utils.js
@@ -35,9 +35,11 @@ exports.hasClass = function (element, className) {
 };
 
 exports.getPrefixedProperty = function (element, propertyName) {
-  var capitalizedPropertName = propertyName[0].toUpperCase() +
+  var capitalizedPropertyName = propertyName[0].toUpperCase() +
     propertyName.slice(1);
 
-  return element[propertyName] || element['moz' + capitalizedPropertName] ||
-    element['webkit' + capitalizedPropertName];
+  return element[propertyName] ||
+    element['webkit' + capitalizedPropertyName] ||
+    element['moz' + capitalizedPropertyName] ||
+    element['ms' + capitalizedPropertyName];
 };

--- a/src/remark/views/slideshowView.js
+++ b/src/remark/views/slideshowView.js
@@ -96,19 +96,28 @@ function SlideshowView (events, dom, containerElement, slideshow) {
 }
 
 function handleFullscreen(self) {
-  var requestFullscreen = utils.getPrefixedProperty(self.containerElement, 'requestFullScreen')
-    , cancelFullscreen = utils.getPrefixedProperty(document, 'cancelFullScreen')
+  var requestFullscreen =
+	      utils.getPrefixedProperty(self.containerElement, 'requestFullscreen') ||
+        utils.getPrefixedProperty(self.containerElement, 'requestFullScreen')
+    , exitFullscreen =
+		    utils.getPrefixedProperty(document, 'exitFullscreen') ||
+        utils.getPrefixedProperty(document, 'cancelFullScreen')
     ;
-
   self.events.on('toggleFullscreen', function () {
-    var fullscreenElement = utils.getPrefixedProperty(document, 'fullscreenElement') ||
-      utils.getPrefixedProperty(document, 'fullScreenElement');
+    var fullscreenElement = utils.getPrefixedProperty(document, 'fullscreenElement');
+		if (fullscreenElement === undefined) {
+      fullscreenElement = utils.getPrefixedProperty(document, 'fullScreenElement');
+		}
 
     if (!fullscreenElement && requestFullscreen) {
-      requestFullscreen.call(self.containerElement, Element.ALLOW_KEYBOARD_INPUT);
+			if (Element.ALLOW_KEYBOARD_INPUT === undefined) {
+				requestFullscreen.call(self.containerElement);
+			} else {
+				requestFullscreen.call(self.containerElement, Element.ALLOW_KEYBOARD_INPUT);
+			}
     }
-    else if (cancelFullscreen) {
-      cancelFullscreen.call(document);
+    else if (exitFullscreen) {
+      exitFullscreen.call(document);
     }
     self.scaleElements();
   });


### PR DESCRIPTION
Using csslint and Microsoft web pages, I made the necessary changes to
get remark working on Internet explorer (at least 10 and 11) and
Microsoft Edge. The fullscreen support doesn't work with keystrokes (but
does work with mouse clicks). Given that Apple doesn't support
keystrokes when in fullscreen mode. And given that remark doesn't work
very well on tablets, one might consider adding buttons along the line
of the slide that contains the 1/xx to have forward, back and fullscreen
buttons. If you added that, the fullscreen support I've added for IE 11
and Edge should just work.

I noticed all these various problem because when I give a talk, I run a
small web server and let the attendees get access to my slides and a
development environment via the web. I've thus even tried to use remark
via a phone.
