### PR TITLE
adding CSS to set black background on body:fullscreen

### DIFF
--- a/src/remark.less
+++ b/src/remark.less
@@ -16,9 +16,21 @@ html.remark-container, body.remark-container {
   outline-style: solid;
   outline-width: 1px;
 }
-:-webkit-full-screen .remark-container {
+.remark-container:-webkit-full-screen {
   width: 100%;
   height: 100%;
+}
+
+body:-webkit-full-screen {
+    background: #000000;
+}
+
+body:-moz-full-screen {
+    background: #000000;
+}
+
+body:fullscreen{
+    background: #000000;
 }
 
 /**********/


### PR DESCRIPTION
(re-trying the pull request, something went wrong with the earlier one, apologies about that one).

I quite liked the idea of @bkeepers in https://github.com/gnab/remark/pull/255 to have a black background on body and also liked @gnab's suggestion to only have that on a body:fullscreen - so went ahead to do that as it was easy to do.