### PR TITLE
Update remark.less

### DIFF
--- a/src/remark.less
+++ b/src/remark.less
@@ -490,6 +490,7 @@ body:fullscreen{
   .remark-slide-scaler {
     -moz-box-shadow: none;
     -webkit-box-shadow: none;
+    -webkit-transform-origin: initial;
     box-shadow: none;
   }
 }


### PR DESCRIPTION
Address printing issue in Chrome Browser
Tested in Chrome 47 (Mac) and Safari 9.0.1