### PR TITLE
Remarkise: better feedback, detect SOP issues

### DIFF
--- a/remarkise.html
+++ b/remarkise.html
@@ -5,6 +5,7 @@
   <head>
 
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="application-name" content="Remarkise">
     <meta name="description" content="Render your markdown as remark slides, in real time">
     <meta name="keywords" content="remark,markdown,md,slide,slideshow,remarkise,tripu">
@@ -113,23 +114,25 @@
       </div>
     </div>
 
-    <script type="text/javascript" src="//code.jquery.com/jquery-2.1.1.min.js"></script>
+    <script type="text/javascript" src="//code.jquery.com/jquery-2.2.1.min.js"></script>
     <script type="text/javascript" src="downloads/remark-latest.min.js"></script>
 
     <script type="text/javascript">
+
+      'use strict';
 
       $(document).ready(function() {
 
         var FIXES = [
           {
-            message: 'Oops, error! But wait — I\'m fetching the “raw” GitHub version instead…'
+            message: "Oops, error! But wait&nbsp;&mdash;&nbsp;I'm fetching the &ldquo;raw&rdquo; GitHub version instead&hellip;"
           , patterns: [
               [/\/\/(www\.)?github.com\//i, '//raw.githubusercontent.com/']
             , [/\/blob\//i, '/']
             ]
           }
         , {
-            message: 'Oops, error! But wait — I\'m fetching it through RawGit…'
+            message: "Oops, error! But wait&nbsp;&mdash;&nbsp;I'm fetching it through RawGit&hellip;"
           , patterns: [
               [/\/\/raw\.githubusercontent\.com\//i, '//rawgit.com/']
             ]
@@ -168,7 +171,7 @@
         function remarkise(url) {
 
           $('div#front-page > div > input').prop('disabled', true);
-          $('div#front-page > div > p').text('Fetching markdown…');
+          $('div#front-page > div > p').html('Fetching markdown&hellip;');
 
           $.ajax({
             url: url,
@@ -185,7 +188,7 @@
                 if (newUrl.toLowerCase() === url.toLowerCase()) {
                   nextFix ++;
                 } else {
-                  $('div#front-page > div > p').text(currentFix.message);
+                  $('div#front-page > div > p').html(currentFix.message);
                 }
 
               }
@@ -193,7 +196,7 @@
               if (newUrl.toLowerCase() !== url.toLowerCase()) {
                 remarkise(newUrl);
               } else {
-                $('div#front-page > div > p').text('Error!');
+                $('div#front-page > div > p').html('Error!');
                 reset();
               }
 

--- a/remarkise.html
+++ b/remarkise.html
@@ -3,7 +3,7 @@
 <html lang="en-GB">
 
   <head>
-    
+
     <meta charset="utf-8">
     <meta name="application-name" content="Remarkise">
     <meta name="description" content="Render your markdown as remark slides, in real time">
@@ -28,7 +28,7 @@
         font-weight:       normal;
       }
 
-      .remark-code,        .remark-inline-code {
+      .remark-code, .remark-inline-code {
         font-family:       'Ubuntu Mono';
       }
 
@@ -269,5 +269,3 @@
   </body>
 
 </html>
-
-<!-- EOF -->

--- a/remarkise.html
+++ b/remarkise.html
@@ -123,40 +123,36 @@
 
       $(document).ready(function() {
 
-        var FIXES = [
+        const FIXES = [
           {
-            message: "Oops, error! But wait&nbsp;&mdash;&nbsp;I'm fetching the &ldquo;raw&rdquo; GitHub version instead&hellip;"
-          , patterns: [
-              [/\/\/(www\.)?github.com\//i, '//raw.githubusercontent.com/']
-            , [/\/blob\//i, '/']
+            message: "Oops, error! But wait&nbsp;&mdash;&nbsp;I'm fetching the &ldquo;raw&rdquo; GitHub version instead&hellip;",
+            patterns: [
+              [/\/\/(www\.)?github.com\//i, '//raw.githubusercontent.com/'],
+              [/\/blob\//i, '/']
             ]
-          }
-        , {
-            message: "Oops, error! But wait&nbsp;&mdash;&nbsp;I'm fetching it through RawGit&hellip;"
-          , patterns: [
+          },
+          {
+            message: "Oops, error! But wait&nbsp;&mdash;&nbsp;I'm fetching it through RawGit&hellip;",
+            patterns: [
               [/\/\/raw\.githubusercontent\.com\//i, '//rawgit.com/']
             ]
           }
-        ]
-        ,   CSS = /<style[^>]*>[^<]*<\/style>/ig
-        ;
+        ];
+        const CSS = /<style[^>]*>[^<]*<\/style>/ig;
 
-        var nextFix = 0
-        ,   currentFix
-        ,   newUrl
-        ,   css
-        ,   i
-        ;
+        var nextFix = 0,
+            currentFix,
+            newUrl,
+            css,
+            i;
 
-        function reset() {
-
+        var reset = function() {
           nextFix = 0;
           $('div#front-page > div > input').prop('disabled', false);
           $('input')[0].value = '';
-
         };
 
-        function createPresentationFromText(data) {
+        var createPresentationFromText = function(data) {
             $('div#front-page').hide();
             css = data.match(CSS);
             if (css) {
@@ -166,9 +162,9 @@
                 }
             }
             remark.create({source: data});
-        }
+        };
 
-        function remarkise(url) {
+        var remarkise = function(url) {
 
           $('div#front-page > div > input').prop('disabled', true);
           $('div#front-page > div > p').html('Fetching markdown&hellip;');
@@ -209,20 +205,16 @@
             }
           });
 
-        }
+        };
 
         if (window.location.search && window.location.search.match(/\?url=.+/)) {
           remarkise(decodeURIComponent(window.location.search.split('=')[1]));
         } else {
-
           $('input').keypress(function(event) {
-
             if (event && 13 === event.keyCode && event.target && event.target.value) {
               remarkise(event.target.value);
             }
-
           });
-
         }
 
         /******************************** konstantinkobs' additions for drag and drop */

--- a/remarkise.html
+++ b/remarkise.html
@@ -65,10 +65,14 @@
         font-style:        italic;
       }
 
-      div#front-page input {
+      div#front-page input#url {
         min-width:         30em;
         max-width:         80%;
         margin-bottom:     0;
+      }
+
+      div#front-page input#button {
+        width:             2em;
       }
 
       /******************************** konstantinkobs' additions */
@@ -108,8 +112,9 @@
           <a href="https://github.com/tripu/remark">remark</a> slides&nbsp;&mdash;&nbsp;in real time
         </p>
         <input id="url" placeholder="URL of a markdown file" autofocus="autofocus" />
+        <input id="button" type="submit" value="&crarr;" />
         <p id="drop-area">
-          or drop a local markdown file here.
+          or drop a local markdown file here
         </p>
       </div>
     </div>
@@ -138,12 +143,15 @@
             ]
           }
         ];
+
         const CSS = /<style[^>]*>[^<]*<\/style>/ig,
-	      head = $('head'),
-	      frontPage = $('div#front-page'),
-	      message = $('div#front-page p#message'),
-	      input = $('div#front-page input#url'),
-	      dropArea = $('div#front-page p#drop-area');
+              HEAD = $('head'),
+              FRONT_PAGE = $('div#front-page'),
+              MESSAGE = $('div#front-page p#message'),
+              INPUT = $('div#front-page input#url'),
+              BUTTON = $('div#front-page input#button'),
+              DROP_AREA = $('div#front-page p#drop-area'),
+              URL_PATTERN = /^(file|https?):\/\/.+/i;
 
         var nextFix = 0,
             currentFix,
@@ -153,17 +161,27 @@
 
         var reset = function() {
           nextFix = 0;
-          input.prop('disabled', false);
-          input[0].value = '';
+          INPUT.prop('disabled', false);
+          INPUT[0].value = '';
+        };
+
+        var trigger = function(event) {
+          if (event && ('click' === event.type || ('keypress' === event.type && 13 === event.keyCode))) {
+            if (URL_PATTERN.test(INPUT[0].value)) {
+              remarkise(INPUT[0].value);
+            } else {
+              MESSAGE.html("That doesn't look like a valid URL :-/");
+            }
+          }
         };
 
         var createPresentationFromText = function(data) {
-            frontPage.hide();
+            FRONT_PAGE.hide();
             css = data.match(CSS);
             if (css) {
                 data = data.replace(CSS, '');
                 for (i in css) {
-                    head.append(css[i]);
+                    HEAD.append(css[i]);
                 }
             }
             remark.create({source: data});
@@ -171,8 +189,8 @@
 
         var remarkise = function(url) {
 
-          input.prop('disabled', true);
-          message.html('Fetching markdown&hellip;');
+          INPUT.prop('disabled', true);
+          MESSAGE.html('Fetching markdown&hellip;');
 
           $.ajax({
             url: url,
@@ -189,7 +207,7 @@
                 if (newUrl.toLowerCase() === url.toLowerCase()) {
                   nextFix ++;
                 } else {
-                  message.html(currentFix.message);
+                  MESSAGE.html(currentFix.message);
                 }
 
               }
@@ -197,7 +215,7 @@
               if (newUrl.toLowerCase() !== url.toLowerCase()) {
                 remarkise(newUrl);
               } else {
-                message.html('Error!');
+                MESSAGE.html('Error!');
                 reset();
               }
 
@@ -215,34 +233,31 @@
         if (window.location.search && window.location.search.match(/\?url=.+/)) {
           remarkise(decodeURIComponent(window.location.search.split('=')[1]));
         } else {
-          input.keypress(function(event) {
-            if (event && 13 === event.keyCode && event.target && event.target.value) {
-              remarkise(event.target.value);
-            }
-          });
+          INPUT.keypress(trigger);
+          BUTTON.click(trigger);
         }
 
         /******************************** konstantinkobs' additions for drag and drop */
 
         if (typeof window.FileReader === 'undefined') {
-          dropArea.removeClass('success');
-          dropArea.addClass('fail');
+          DROP_AREA.removeClass('success');
+          DROP_AREA.addClass('fail');
         } else {
-          dropArea.removeClass('fail');
-          dropArea.addClass('success');
+          DROP_AREA.removeClass('fail');
+          DROP_AREA.addClass('success');
         }
 
-        dropArea.on("dragover", function(){
+        DROP_AREA.on("dragover", function(){
           $(this).addClass("hover");
           return false;
         });
 
-        dropArea.on("dragend", function(){
+        DROP_AREA.on("dragend", function(){
           $(this).removeClass("hover");
           return false;
         });
 
-        dropArea.on("drop", function(e){
+        DROP_AREA.on("drop", function(e){
           $(this).removeClass("hover");
 
           e.preventDefault();

--- a/remarkise.html
+++ b/remarkise.html
@@ -65,6 +65,10 @@
         font-style:        italic;
       }
 
+      div#front-page p span.smaller {
+        font-size:         smaller;
+      }
+
       div#front-page input#url {
         min-width:         30em;
         max-width:         80%;
@@ -187,6 +191,12 @@
             remark.create({source: data});
         };
 
+        var getOrigin = function(url) {
+          var foo = document.createElement('a');
+          foo.href = url;
+          return foo.origin;
+        };
+
         var remarkise = function(url) {
 
           INPUT.prop('disabled', true);
@@ -215,7 +225,17 @@
               if (newUrl.toLowerCase() !== url.toLowerCase()) {
                 remarkise(newUrl);
               } else {
-                MESSAGE.html('Error!');
+                if (window.location.origin.toLowerCase() === getOrigin(url).toLowerCase()) {
+                  MESSAGE.html('Error!');
+                } else {
+                  MESSAGE.html('Error! (probably a violation of the ' +
+                    '<a href="https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy">same-origin policy</a>) <br><br> ' +
+                    '<span class="smaller">What you can do: <br> ' +
+                    '&#8227; If you own <a href="' + getOrigin(url) + '"><code>' + getOrigin(url) + '</code></a>, try ' +
+                    '<a href="https://stackoverflow.com/search?q=enable+CORS+on+server">enabling CORS</a> on that domain. <br> ' +
+                    '&#8227; If you can, bring your presentation over here, to <a href="' + window.location.origin + '"><code>' +
+                    window.location.origin + '</code></a>.');
+                }
                 reset();
               }
 

--- a/remarkise.html
+++ b/remarkise.html
@@ -41,7 +41,7 @@
         height:            100%;
       }
 
-      div#front-page > div {
+      div#front-page div {
         position:          relative;
         top:               50%;
         -webkit-transform: translateY(-50%);
@@ -52,20 +52,20 @@
         text-align:        center;
       }
 
-      div#front-page > div > h1 {
+      div#front-page h1 {
         margin-top:        0;
         font-weight:       bold;
       }
 
-      div#front-page > div > h1 > span {
+      div#front-page h1 span {
         color:             #c00000;
       }
 
-      div#front-page > div > p {
+      div#front-page p {
         font-style:        italic;
       }
 
-      div#front-page > div > input {
+      div#front-page input {
         min-width:         30em;
         max-width:         80%;
         margin-bottom:     0;
@@ -73,7 +73,7 @@
 
       /******************************** konstantinkobs' additions */
 
-      div#front-page > div > p#drop-area {
+      div#front-page p#drop-area {
         width: 30em;
         max-width: 80%;
         border: 0.2em dashed #999;
@@ -82,15 +82,15 @@
         margin: 1em auto;
       }
 
-      div#front-page > div > p#drop-area.hover {
+      div#front-page p#drop-area.hover {
         background: #eee;
       }
 
-      div#front-page > div > p#drop-area.fail {
+      div#front-page p#drop-area.fail {
         display: none;
       }
 
-      div#front-page > div > p#drop-area.success {
+      div#front-page p#drop-area.success {
         display: block;
       }
 
@@ -103,7 +103,7 @@
     <div id="front-page">
       <div>
         <h1>Remark<span>ise</span></h1>
-        <p>
+        <p id="message">
           Render your <a href="http://commonmark.org/">markdown</a> as
           <a href="https://github.com/tripu/remark">remark</a> slides&nbsp;&mdash;&nbsp;in real time
         </p>
@@ -138,7 +138,12 @@
             ]
           }
         ];
-        const CSS = /<style[^>]*>[^<]*<\/style>/ig;
+        const CSS = /<style[^>]*>[^<]*<\/style>/ig,
+	      head = $('head'),
+	      frontPage = $('div#front-page'),
+	      message = $('div#front-page p#message'),
+	      input = $('div#front-page input#url'),
+	      dropArea = $('div#front-page p#drop-area');
 
         var nextFix = 0,
             currentFix,
@@ -148,17 +153,17 @@
 
         var reset = function() {
           nextFix = 0;
-          $('div#front-page > div > input').prop('disabled', false);
-          $('input')[0].value = '';
+          input.prop('disabled', false);
+          input[0].value = '';
         };
 
         var createPresentationFromText = function(data) {
-            $('div#front-page').hide();
+            frontPage.hide();
             css = data.match(CSS);
             if (css) {
                 data = data.replace(CSS, '');
                 for (i in css) {
-                    $('head').append(css[i]);
+                    head.append(css[i]);
                 }
             }
             remark.create({source: data});
@@ -166,8 +171,8 @@
 
         var remarkise = function(url) {
 
-          $('div#front-page > div > input').prop('disabled', true);
-          $('div#front-page > div > p').html('Fetching markdown&hellip;');
+          input.prop('disabled', true);
+          message.html('Fetching markdown&hellip;');
 
           $.ajax({
             url: url,
@@ -184,7 +189,7 @@
                 if (newUrl.toLowerCase() === url.toLowerCase()) {
                   nextFix ++;
                 } else {
-                  $('div#front-page > div > p').html(currentFix.message);
+                  message.html(currentFix.message);
                 }
 
               }
@@ -192,7 +197,7 @@
               if (newUrl.toLowerCase() !== url.toLowerCase()) {
                 remarkise(newUrl);
               } else {
-                $('div#front-page > div > p').html('Error!');
+                message.html('Error!');
                 reset();
               }
 
@@ -210,7 +215,7 @@
         if (window.location.search && window.location.search.match(/\?url=.+/)) {
           remarkise(decodeURIComponent(window.location.search.split('=')[1]));
         } else {
-          $('input').keypress(function(event) {
+          input.keypress(function(event) {
             if (event && 13 === event.keyCode && event.target && event.target.value) {
               remarkise(event.target.value);
             }
@@ -218,7 +223,6 @@
         }
 
         /******************************** konstantinkobs' additions for drag and drop */
-        var dropArea = $("div#front-page > div > p#drop-area");
 
         if (typeof window.FileReader === 'undefined') {
           dropArea.removeClass('success');


### PR DESCRIPTION
[Remarkise](https://gnab.github.io/remark/remarkise): fix gnab/remark#301 by showing better error messages and advising the user when we detect a probable violation of the same-origin policy (or CORS not working).

This tries to detect cross-domain requests by simply comparing origins.

While at it:
* Bugfix: don't change message in `#drop-area` too (that should remain unchanged); feedback messages via subheading only
* Add button to form for better usability; listen to events in both text field and button
* Detect wrong URLs and tell the user, eg `hhtp://typo-in-protocol.com`
* Simplify selectors (CSS and jQuery); optimise selectors: run them just once!
* Use latest version of jQuery
* Add `viewport` meta header (for iPhone)
* Switch to JS' *strict mode*
* Coding style:
  * Use `const` wherever appropriate
  * All constants in UPPERCASE
  * Change style of multiple `var` declarations (remove ugly commas at the beginning of lines.
  * Declare functions as variables too
  * Use entities instead of UCS chars (files become pure ASCII: smaller, simpler to parse, better compatibility)
  * Fix some whitespaces