### PR TITLE
Removed link to remark presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ Other interesting stuff:
 - [torgeir.github.com/busterjs-lightning-talk](http://torgeir.github.com/busterjs-lightning-talk)
 - [roberto.github.com/ruby-sinform-2012](http://roberto.github.com/ruby-sinform-2012)
 - [http://asmeurer.github.io/python3-presentation/slides.html](http://asmeurer.github.io/python3-presentation/slides.html)
-- [Lecture notes using remark](http://ozan.keysan.me/ee361/)
 - [Big Data in Time - Progress and Challenges from Oceanography](http://www.jmlilly.net/talks/bigdata16.html)
 
 ### Other systems integrating with remark


### PR DESCRIPTION
Doesn't look like it exists anymore