### PR TITLE
Fix content classes with inherited templates, include path fixes

### DIFF
--- a/src/remark.js
+++ b/src/remark.js
@@ -1,6 +1,6 @@
 var Api = require('./remark/api')
   , polyfills = require('./polyfills')
-  , styler = require('components/styler')
+  , styler = require('./remark/components/styler/styler')
   ;
 
 // Expose API as `remark`

--- a/src/remark/components/printing/printing.js
+++ b/src/remark/components/printing/printing.js
@@ -1,5 +1,5 @@
 var EventEmitter = require('events').EventEmitter
-  , styler = require('components/styler')
+  , styler = require('../styler/styler')
   ;
 
 var LANDSCAPE = 'landscape'

--- a/src/remark/converter.js
+++ b/src/remark/converter.js
@@ -33,7 +33,7 @@ function convertMarkdown (content, links, insideContentClass) {
     else {
       tag = content[i].block ? 'div' : 'span';
       markdown += '<' + tag + ' class="' + content[i].class + '">';
-      markdown += convertMarkdown(content[i].content, links, true);
+      markdown += convertMarkdown(content[i].content, links, !content[i].block);
       markdown += '</' + tag + '>';
     }
   }

--- a/src/remark/models/slide.js
+++ b/src/remark/models/slide.js
@@ -55,12 +55,8 @@ function ignoreProperty (property) {
 function inheritContent (slide, template) {
   var expandedVariables;
 
-  function chunkEncoder(chunk) {
-    return converter.convertMarkdown(Array.isArray(chunk) ? chunk : [chunk], [], false);
-  }
-
-  slide.properties.content = slide.content.slice().map(chunkEncoder).reduce(function(a, c) { return a + c; }, "");
-  slide.content = template.content.slice().map(chunkEncoder);
+  slide.properties.content = slide.content.slice();
+  slide.content = template.content.slice();
 
   expandedVariables = slide.expandVariables(/* contentOnly: */ true);
 

--- a/src/remark/models/slide.js
+++ b/src/remark/models/slide.js
@@ -55,13 +55,12 @@ function ignoreProperty (property) {
 function inheritContent (slide, template) {
   var expandedVariables;
 
-  slide.properties.content = slide.content.slice().reduce(function(content, chunk) {
-    if (typeof chunk !== 'string') {
-        chunk = converter.convertMarkdown([chunk], [], false);
-    }
-    return content + chunk;
-  }, "");
-  slide.content = template.content.slice();
+  function chunkEncoder(chunk) {
+    return converter.convertMarkdown(Array.isArray(chunk) ? chunk : [chunk], [], false);
+  }
+
+  slide.properties.content = slide.content.slice().map(chunkEncoder).reduce(function(a, c) { return a + c; }, "");
+  slide.content = template.content.slice().map(chunkEncoder);
 
   expandedVariables = slide.expandVariables(/* contentOnly: */ true);
 

--- a/src/remark/models/slide.js
+++ b/src/remark/models/slide.js
@@ -1,3 +1,5 @@
+var converter = require('../converter');
+
 module.exports = Slide;
 
 function Slide (slideIndex, slide, template) {
@@ -53,7 +55,12 @@ function ignoreProperty (property) {
 function inheritContent (slide, template) {
   var expandedVariables;
 
-  slide.properties.content = slide.content.slice();
+  slide.properties.content = slide.content.slice().reduce(function(content, chunk) {
+    if (typeof chunk !== 'string') {
+        chunk = converter.convertMarkdown([chunk], [], false);
+    }
+    return content + chunk;
+  }, "");
   slide.content = template.content.slice();
 
   expandedVariables = slide.expandVariables(/* contentOnly: */ true);

--- a/src/remark/views/slideView.js
+++ b/src/remark/views/slideView.js
@@ -1,4 +1,4 @@
-var SlideNumber = require('components/slide-number')
+var SlideNumber = require('../components/slide-number/slide-number')
   , converter = require('../converter')
   , highlighter = require('../highlighter')
   , utils = require('../utils')

--- a/src/remark/views/slideshowView.js
+++ b/src/remark/views/slideshowView.js
@@ -1,10 +1,10 @@
 var SlideView = require('./slideView')
-  , Timer = require('components/timer')
+  , Timer = require('../components/timer/timer')
   , NotesView = require('./notesView')
   , Scaler = require('../scaler')
   , resources = require('../resources')
   , utils = require('../utils')
-  , printing = require('components/printing')
+  , printing = require('../components/printing/printing')
   ;
 
 module.exports = SlideshowView;


### PR DESCRIPTION
Re content classes: the following markup would output `[Object object]` instead of the content class' inner markup if used with template inheritance. eg:

    layout: true

    Header text

    {{ content }}

    Footer text

    ---
    
    .left-column[
        # First section
    ]

    .right-column[
        ## Slide title

        body text
    ]

Re include path fixes: not sure what build system you were using, but needed to set all include paths to be relative in order to load `remark/src/remark/api` etc directly into node, rollup or webpack.