### PR TITLE
Update and remove broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,12 @@ Other interesting stuff:
 - [torgeir.github.com/busterjs-lightning-talk](http://torgeir.github.com/busterjs-lightning-talk)
 - [roberto.github.com/ruby-sinform-2012](http://roberto.github.com/ruby-sinform-2012)
 - [http://asmeurer.github.io/python3-presentation/slides.html](http://asmeurer.github.io/python3-presentation/slides.html)
-- [Lecture notes using remark](http://ozan.keysan.me/ee361/)
+- [Lecture notes using remark](http://keysan.me/ee361/)
 - [Big Data in Time - Progress and Challenges from Oceanography](http://www.jmlilly.net/talks/bigdata16.html)
 
 ### Other systems integrating with remark
 
 - [http://platon.io](http://platon.io)
-- [http://www.markdowner.com](http://www.markdowner.com)
-- [http://remarks.sinaapp.com](http://remarks.sinaapp.com/)
 - [Remarkymark (Remark.js in Middleman)](https://github.com/camerond/remarkymark)
 
 ### Printing


### PR DESCRIPTION
- "Lecture notes using remark", originally http://ozan.keysan.me/ee361/, moved to http://keysan.me/ee361/
- [Markdowner](http://www.markdowner.com/) is dead. I removed the link completely, but alternatively a link to one of the following similar sites could be added [Dillinger](http://dillinger.io/), [StackEdit](https://stackedit.io/editor), [jbt.github.io/markdown-editor/](https://jbt.github.io/markdown-editor/) or [Markable.in](https://markable.in/)
- [Remarks](http://remarks.sinaapp.com/) is also dead and I couldn't find any alternative.