### PR TITLE
Remove markdowner from README.md as project no longer exists #354

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Other interesting stuff:
 ### Other systems integrating with remark
 
 - [http://platon.io](http://platon.io)
-- [http://www.markdowner.com](http://www.markdowner.com)
 - [http://remarks.sinaapp.com](http://remarks.sinaapp.com/)
 - [Remarkymark (Remark.js in Middleman)](https://github.com/camerond/remarkymark)
 


### PR DESCRIPTION
Markdowner.com domain no longer works and github issue https://github.com/mikaelbr/markdowner/issues/8 confirms project no longer active.