### PR TITLE
Add SPDX-compatible "MIT" license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/gnab/remark.git"
   },
+  "license": "MIT",
   "devDependencies": {
     "browserify": "^13.0.0",
     "grunt": "^0.4.5",


### PR DESCRIPTION
This helps automatic parsers determine licenses for legal departments; see https://docs.npmjs.com/files/package.json#license