### PR TITLE
Implement `cloneTarget` option

### DIFF
--- a/src/remark/models/slideshow.js
+++ b/src/remark/models/slideshow.js
@@ -45,6 +45,7 @@ function Slideshow (events, dom, options, callback) {
   self.getHighlightInlineCode = getOrDefault('highlightInlineCode', false);
   self.getHighlightLanguage = getOrDefault('highlightLanguage', '');
   self.getSlideNumberFormat = getOrDefault('slideNumberFormat', '%current% / %total%');
+  self.getCloneTarget = getOrDefault('cloneTarget', '_blank');
 
   events.on('toggleBlackout', function () {
     if (self.clone && !self.clone.closed) {

--- a/src/remark/models/slideshow/navigation.js
+++ b/src/remark/models/slideshow/navigation.js
@@ -29,7 +29,7 @@ function Navigation (events) {
 
   events.on('createClone', function () {
     if (!self.clone || self.clone.closed) {
-      self.clone = window.open(location.href, '_blank', 'location=no');
+      self.clone = window.open(location.href, self.getCloneTarget(), 'location=no');
     }
     else {
       self.clone.focus();


### PR DESCRIPTION
In my experience, it's distracting to close an old "clone" and move a new
"clone" into place between presentations of multiple slide shows. This patch
parameterizes the "target" to `window.open` so that the current behavior (e.g.
a new window for each clone) is preserved, but users may opt-in to a "shared
clone" behavior. I'm suggesting that we parameterize the "name" itself (instead
of exposing this as a boolean configuration value) so that users have more
control over how clones are managed.

Thanks for the great tool!

Commit message:

> Presentations built with Remark.js may span multiple HTML files. In such
> contexts, managing the distinct windows created by each "clone"
> operation can be disruptive to the flow of the presentation.
>
> Allow for configuration of the "cloned" window's name. Users wishing to
> re-use the same window between multiple slide shows may do so by
> specifying a value other than "_blank".