### PR TITLE
Add pille1842/repositorium to systems using remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Other interesting stuff:
 - [http://platon.io](http://platon.io)
 - [Remarkymark (Remark.js in Middleman)](https://github.com/camerond/remarkymark)
 - [Remark Boilerplate](https://github.com/brenopolanski/remark-boilerplate)
+- [Repositorium](https://github.com/pille1842/repositorium)
 
 ### Printing
 


### PR DESCRIPTION
Hey there! My Git-based Markdown wiki engine written in PHP, Repositorium, allows you to view any Markdown page as a remark slideshow with one click. I thought maybe you'd like to feature it in your list of systems integrating with remark. Cheers!