### PR TITLE
Allow to exclude sets of slides by class

### DIFF
--- a/src/remark/models/slideshow.js
+++ b/src/remark/models/slideshow.js
@@ -205,8 +205,16 @@ function createSlides (slideshowSource, options) {
       byName[slide.properties.name] = slideViewModel;
     }
 
+    var slideClasses = (slide.properties['class'] || '').split(/,| /)
+      , excludedClasses = options.excludedClasses || []
+      , slideIsIncluded = slideClasses.filter(function (c) {
+          return excludedClasses.indexOf(c) !== -1;
+        }).length === 0;
+
     if (slide.properties.layout !== 'true') {
-      slides.push(slideViewModel);
+      if (slideIsIncluded) {
+        slides.push(slideViewModel);
+      }
       if (slide.properties.name) {
         slides.byName[slide.properties.name] = slideViewModel;
       }


### PR DESCRIPTION
*Long time user, first time contributor... ;-)*

This patch adds an option exclude slides
depending on their class. This allows to turn
on or off chapters, sections, or extra material
very easily. Example:

```
     var slideshow = remark.create({
        ratio: '16:9',
        excludedClasses: ["in-person", "extra-details"]
      });
```

With this setting, all slides having `class: in-person`
or `class: extra-details` will be skipped, as if they
had the `excluded: true` property.

My use case is the following: I have a rather big slides
deck (~350 slides) that I use for workshops and tutorials.
I often enable and disable sections, depending on
how long the tutorial should be; what people want to
learn; and whether people are doing this with an
instructor, or at their own pace at home. I used to
enable and disable slides, sections, and snippets,
by using various tricks (HTML comments, `exclude`,
putting things in slides notes ith `???`...) but
I want something more efficient; so I'm proposing
the following change.

Let me know if this is the correct approach. I will
be happy to follow your feedback. I didn't add tests,
but I can if it's necessary (I'll just need some
guidelines about the kind of cases that you'd like me
to check.)

Thank you!