### PR TITLE
Fix #418 'mixed content' error due to redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ class: center, middle
 # Introduction
 
     </textarea>
-    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js">
+    <script src="https://remarkjs.com/downloads/remark-latest.min.js">
     </script>
     <script>
       var slideshow = remark.create();


### PR DESCRIPTION
Previous github link redirects twice to a HTTP address.
Further details given in the conversation for #418 .