### PR TITLE
Added Backslide reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Other interesting stuff:
 - [Remarkymark (Remark.js in Middleman)](https://github.com/camerond/remarkymark)
 - [Remark Boilerplate](https://github.com/brenopolanski/remark-boilerplate)
 - [Repositorium](https://github.com/pille1842/repositorium)
+- [Backslide](https://github.com/sinedied/backslide) - CLI for automating creation, export and PDF conversion of Remark presentations
 
 ### Printing
 


### PR DESCRIPTION
I just finished [Backslide](https://github.com/sinedied/backslide), a complete CLI tool to ease the creation, editing and exporting of Remark presentation 😋 

I added a link reference to it in your readme file, thought that some people might be interested ;)

Thanks for the nice job with Remark BTW! 👍 