### PR TITLE
Allow custom delimiters for highlightSpans

### DIFF
--- a/src/remark/views/slideView.js
+++ b/src/remark/views/slideView.js
@@ -253,7 +253,8 @@ function highlightCodeBlocks (content, slideshow) {
     }
 
     if (highlightSpans) {
-      highlightBlockSpans(block);
+      // highlightSpans is either true or a RegExp
+      highlightBlockSpans(block, highlightSpans);
     }
 
     utils.addClass(block, 'remark-code');
@@ -296,8 +297,23 @@ function highlightBlockLines (block, lines) {
   });
 }
 
-function highlightBlockSpans (block) {
-  var pattern = /([^`])`([^`]+?)`/g ;
+/**
+ * @param highlightSpans `true` or a RegExp
+ */
+function highlightBlockSpans (block, highlightSpans) {
+  var pattern;
+  if (highlightSpans === true) {
+    pattern = /([^`])`([^`]+?)`/g;
+  } else if (highlightSpans instanceof RegExp) {
+    if (! highlightSpans.global) {
+      throw new Error('The regular expression in `highlightSpans` must have flag /g');
+    }
+    // Use [^] instead of dot (.) so that even newlines match
+    // We prefix the escape group, so users can provide nicer regular expressions
+    pattern = new RegExp('([^])' + highlightSpans.slice(1, -1), highlightSpans.flags);
+  } else {
+    throw new Error('Illegal value for `highlightSpans`');
+  }
 
   block.childNodes.forEach(function (element) {
     element.innerHTML = element.innerHTML.replace(pattern,

--- a/test/remark/views/slideView_test.js
+++ b/test/remark/views/slideView_test.js
@@ -201,6 +201,28 @@ describe('SlideView', function () {
       lines[0].innerHTML.should.equal('a `f` b');
     });
 
+    it('should allow custom delimiters', function () {
+      slideshow.getHighlightSpans = function () { return /«([^»]+?)»/g; };
+
+      var slide = new Slide(1, { content: ['```\na «f» b\n```'] });
+      slideshow.slides.push(slide);
+      var slideView = new SlideView(new EventEmitter(), slideshow, scaler, slide);
+
+      var lines = slideView.element.getElementsByClassName('remark-code-line');
+      lines[0].innerHTML.should.equal('a <span class="remark-code-span-highlighted">f</span> b');
+    });
+
+    it('should allow escaping opening custom delimiter', function () {
+      slideshow.getHighlightSpans = function () { return /«([^»]+?)»/g; };
+
+      var slide = new Slide(1, { content: ['```\na \\«f» b\n```'] });
+      slideshow.slides.push(slide);
+      var slideView = new SlideView(new EventEmitter(), slideshow, scaler, slide);
+
+      var lines = slideView.element.getElementsByClassName('remark-code-line');
+      lines[0].innerHTML.should.equal('a «f» b');
+    });
+
     it('should be possible to disable', function () {
       slideshow.getHighlightSpans = function () { return false; };
 


### PR DESCRIPTION
Now there are three kinds of values one can assign to highlightSpans:

* `false`: span highlighting is off
* `true`: enables backticks for highlighting
* A RegExp: custom delimiters. For example:
    ```js
    highlightSpans: /«([^»]+?)»/g,
    ```

I’m prefixing the escape capture group to the user-provided regular expression, which is not pretty, but the most concise solution I could find.
