### PR TITLE
docs: add link to remarker

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Other interesting stuff:
 - [Remark Boilerplate](https://github.com/brenopolanski/remark-boilerplate)
 - [Repositorium](https://github.com/pille1842/repositorium)
 - [Backslide](https://github.com/sinedied/backslide) - CLI for automating creation, export and PDF conversion of Remark presentations
+- [Remarker](https://github.com/kt3k/remarker) - CLI for serving and building Remark slideshow from markdown file
 
 ### Printing
 


### PR DESCRIPTION
Hello

Thanks for the great presentation tool!

I created cli tool for serving and building remark slideshow from markdown input file, called `remarker`, and I added the link to it in README.md.

Thanks

---
**Note:**
This tool is similar to `backslide` but doesn't require html, js and css files at all. It directly serves and builds from only input markdown file, so you don't need to manage files except markdown file and that's the point of it.