### PR TITLE
Prevent default on keys that can trigger browser functionality like fast search

### DIFF
--- a/src/remark/controllers/inputs/keyboard.js
+++ b/src/remark/controllers/inputs/keyboard.js
@@ -2,13 +2,13 @@ module.exports = Keyboard;
 
 function Keyboard(events) {
   this._events = events;
-  
+
   this.activate();
 }
 
 Keyboard.prototype.activate = function () {
   this._gotoSlideNumber = '';
-  
+
   this.addKeyboardEventListeners();
 };
 
@@ -19,7 +19,7 @@ Keyboard.prototype.deactivate = function () {
 Keyboard.prototype.addKeyboardEventListeners = function () {
   var self = this;
   var events = this._events;
-  
+
   events.on('keydown', function (event) {
     if (event.metaKey || event.ctrlKey) {
       // Bail out if meta or ctrl key was pressed
@@ -67,49 +67,59 @@ Keyboard.prototype.addKeyboardEventListeners = function () {
       // Bail out if meta or ctrl key was pressed
       return;
     }
-    
+
     var key = String.fromCharCode(event.which).toLowerCase();
 
     switch (key) {
       case 'j':
         events.emit('gotoNextSlide');
+        event.preventDefault();
         break;
       case 'k':
         events.emit('gotoPreviousSlide');
+        event.preventDefault();
         break;
       case 'b':
         events.emit('toggleBlackout');
+        event.preventDefault();
         break;
       case 'm':
         events.emit('toggleMirrored');
+        event.preventDefault();
         break;
       case 'c':
         events.emit('createClone');
+        event.preventDefault();
         break;
       case 'p':
         events.emit('togglePresenterMode');
+        event.preventDefault();
         break;
       case 'f':
         events.emit('toggleFullscreen');
+        event.preventDefault();
         break;
       case 't':
         events.emit('resetTimer');
+        event.preventDefault();
         break;
-      case '1': 
-      case '2': 
-      case '3': 
-      case '4': 
+      case '1':
+      case '2':
+      case '3':
+      case '4':
       case '5':
-      case '6': 
-      case '7': 
-      case '8': 
-      case '9': 
+      case '6':
+      case '7':
+      case '8':
+      case '9':
       case '0':
         self._gotoSlideNumber += key;
+        event.preventDefault();
         break;
       case 'h':
       case '?':
         events.emit('toggleHelp');
+        event.preventDefault();
         break;
     }
   });
@@ -117,7 +127,7 @@ Keyboard.prototype.addKeyboardEventListeners = function () {
 
 Keyboard.prototype.removeKeyboardEventListeners = function () {
   var events = this._events;
-  
+
   events.removeAllListeners("keydown");
   events.removeAllListeners("keypress");
 };


### PR DESCRIPTION
Remark uses several keyboard shortcuts with no accelerator key (eg. `p` for presenter mode). In some off-the-shelf browser configurations this triggers functionality (for instance, to search for matching links). As a general rule, keys handled for actions should not also trigger their default behaviour.

This patch simply calls `preventDefault()` in applicable cases.