### PR TITLE
Bugfix: "node make" could not work if the path contains a space chara…

### DIFF
--- a/make.js
+++ b/make.js
@@ -208,7 +208,7 @@ function git (cmd) {
 }
 
 function run (command, loud) {
-  var result = exec(pwd() + '/node_modules/.bin/' + command, {silent: !loud, fatal: false});
+  var result = exec('"' + pwd() + '/node_modules/.bin/' + '"' + command, {silent: !loud, fatal: false});
 
   if (result.code !== 0) {
     if (!options || options.silent) {


### PR DESCRIPTION
I tried to do "node make all" in a path that contains a space character (e.g. `/my projects/remark`) and that did not work. This fix makes it possible.