### PR TITLE
Fix #446

### DIFF
--- a/src/remark/lexer.js
+++ b/src/remark/lexer.js
@@ -30,7 +30,7 @@ var block = replace(/CODE|INLINE_CODE|CONTENT|FENCES|DEF|MACRO|SEPARATOR|NOTES_S
 function Lexer () { }
 
 Lexer.prototype.lex = function (src) {
-  var tokens = lex(src, block),
+  var tokens = lex(src.replace('\r', ''), block),
       i;
 
   for (i = tokens.length - 2; i >= 0; i--) {


### PR DESCRIPTION
Alter lexer.js so that any carriage returns are stripped from the source prior to lexical analysis.

This allows remark to support windows line endings.