### PR TITLE
Font size

### DIFF
--- a/src/remark.less
+++ b/src/remark.less
@@ -102,10 +102,6 @@ body:fullscreen{
   display: table-cell;
   padding: 1em 4em 1em 4em;
 
-  h1 { font-size: 55px; }
-  h2 { font-size: 45px; }
-  h3 { font-size: 35px; }
-
   .left {
     display: block;
     text-align: left;

--- a/src/remark.less
+++ b/src/remark.less
@@ -132,7 +132,7 @@ body:fullscreen{
 }
 
 .remark-code {
-  font-size: 18px;
+  font-size: smaller;
 }
 .remark-code-line {
   min-height: 1em;

--- a/src/remark.less
+++ b/src/remark.less
@@ -2,6 +2,9 @@
 /* Container */
 /*************/
 
+html {
+  font-size: 20px;
+}
 html.remark-container, body.remark-container {
   height: 100%;
   width: 100%;
@@ -97,7 +100,6 @@ body:fullscreen{
   background-position: center;
   background-repeat: no-repeat;
   display: table-cell;
-  font-size: 20px;
   padding: 1em 4em 1em 4em;
 
   h1 { font-size: 55px; }


### PR DESCRIPTION
- Move the default font-size to html tag, so that it can easily be overridden by local CSS file
- Remove fixed-sized headings, browser defaults are usually sane with respect to default font-size
- Change fixed-sized code to relative size