### PR TITLE
Option for disabling incremental slides

### DIFF
--- a/src/remark/models/slideshow.js
+++ b/src/remark/models/slideshow.js
@@ -171,7 +171,7 @@ function Slideshow (events, dom, options, callback) {
 
 function createSlides (slideshowSource, options) {
   var parser = new Parser()
-   ,  parsedSlides = parser.parse(slideshowSource, macros)
+   ,  parsedSlides = parser.parse(slideshowSource, macros, options)
     , slides = []
     , byName = {}
     , layoutSlide

--- a/src/remark/parser.js
+++ b/src/remark/parser.js
@@ -99,6 +99,14 @@ Parser.prototype.parse = function (src, macros, options) {
         stack.pop();
         break;
       case 'separator':
+        // Just continue on the same slide if incremental slides are disabled
+        if (token.text === '--' && options.disableIncrementalSlides === true) {
+          // If it happens that there was a note section right before, just get
+          // rid of it
+          if (stack[0].notes !== undefined)
+            delete(stack[0].notes);
+          break;
+        }
         // Slide separator (--- or --), so add current slide to list of
         // slides and re-initialize stack with new, blank slide.
         slides.push(stack[0]);

--- a/src/remark/parser.js
+++ b/src/remark/parser.js
@@ -35,7 +35,7 @@ function Parser () { }
  *    ...
  *  ]
  */
-Parser.prototype.parse = function (src, macros) {
+Parser.prototype.parse = function (src, macros, options) {
   var self = this,
       lexer = new Lexer(),
       tokens = lexer.lex(cleanInput(src)),
@@ -46,6 +46,7 @@ Parser.prototype.parse = function (src, macros) {
       stack = [createSlide()];
 
   macros = macros || {};
+  options = options || {};
 
   tokens.forEach(function (token) {
     switch (token.type) {


### PR DESCRIPTION
Introduce new option disableIncrementalSlides; if set to true, flatten out incremental slides into single slide with all the contents. Ideally for slide printouts!