### PR TITLE
Travis CI: test with Node.js 6 and 8 (not 0.10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6"
+  - "8"


### PR DESCRIPTION
Node.js `0.10` is OLD.

This addresses my comment here: https://github.com/gnab/remark/commit/bb1a48f0da6f754721bab4a133a057b147b0286a#commitcomment-26719952.

This build is failing here due to the bug that #497 fixes; both PRs should be merged. (See here [successful builds with Node.js 6 and 8](https://travis-ci.org/tripu/remark/builds/326761975).)