### PR TITLE
Change document.origin to window.origin on DOM JS

### DIFF
--- a/src/remark/dom.js
+++ b/src/remark/dom.js
@@ -21,7 +21,7 @@ Dom.prototype.getLocationHash = function () {
 };
 
 Dom.prototype.setLocationHash = function (hash) {
-  if (typeof window.history.replaceState === 'function' && document.origin !== 'null') {
+  if (typeof window.history.replaceState === 'function' && window.origin !== 'null') {
     window.history.replaceState(undefined, undefined, hash);
   }
   else {


### PR DESCRIPTION
A deprecation warning has been issue on Chrome about DOM API  method `document.origin`. I changed  to `window.origin`

![screen shot 2018-08-22 at 09 24 46](https://user-images.githubusercontent.com/10330222/44453238-7e083000-a5f0-11e8-84be-68518664f4c9.png)

![screen shot 2018-08-22 at 09 25 00](https://user-images.githubusercontent.com/10330222/44453262-8bbdb580-a5f0-11e8-919e-6bfeddd2d13c.png)
