### PR TITLE
feat: add a function to throttle scrolling events

### DIFF
--- a/src/remark/controllers/inputs/mouse.js
+++ b/src/remark/controllers/inputs/mouse.js
@@ -6,6 +6,17 @@ exports.unregister = function (events) {
   removeMouseEventListeners(events);
 };
 
+function throttle(events, eventName) {
+  var timestamp = null;
+  return function() {
+    var now = Date.now();
+    if (timestamp === null || now - timestamp > 100) {
+      events.emit(eventName);
+    }
+    timestamp = now;
+  };
+}
+
 function addMouseEventListeners (events, options) {
   if (options.click) {
     events.on('click', function (event) {
@@ -27,13 +38,15 @@ function addMouseEventListeners (events, options) {
     });
   }
 
+  var throttledPrev = throttle(events, 'gotoPreviousSlide');
+  var throttledNext = throttle(events, 'gotoNextSlide');
   if (options.scroll !== false) {
     var scrollHandler = function (event) {
       if (event.wheelDeltaY > 0 || event.detail < 0) {
-        events.emit('gotoPreviousSlide');
+        throttledPrev();
       }
       else if (event.wheelDeltaY < 0 || event.detail > 0) {
-        events.emit('gotoNextSlide');
+        throttledNext();
       }
     };
 


### PR DESCRIPTION
In the [remark slideshow](https://remarkjs.com/#1). If you scroll on your touch pad even a little, the slides will go forward/back multiple slides. I add a function to throttle emitters of scrolling. Therefore, the slides will only change by 1 when a user scrolls.