### PR TITLE
Implement multi-slide macros

### DIFF
--- a/src/remark/parser.js
+++ b/src/remark/parser.js
@@ -78,6 +78,14 @@ Parser.prototype.parse = function (src, macros, options) {
         if (typeof value === 'string') {
           value = self.parse(value, macros);
           appendTo(stack[stack.length - 1], value[0].content[0]);
+          if (value.length > 1) {
+            slides.push(stack[0]);
+            value.slice(1, -1).forEach(function (slide) {
+              slides.push(slide);
+            });
+            stack = [createSlide()];
+            appendTo(stack[0], slides[slides.length - 1].content[0]);
+          }
         }
         else {
           appendTo(stack[stack.length - 1], value === undefined ?

--- a/test/remark/parser_test.js
+++ b/test/remark/parser_test.js
@@ -128,6 +128,69 @@ describe('Parser', function () {
       parser.parse('Uppercase => ![:addupper](word)', macros)[0].content
         .should.eql(['Uppercase => WORD']);
     });
+
+    it('should not end the slide if a macro returns only one slide', function () {
+      var macros = {
+        upper: function () {
+          return this.toUpperCase();
+        }
+      };
+      parser.parse('previous ![:upper](word) after', macros)[0].content
+        .should.eql(['previous WORD after']);
+    });
+
+    it('should add slides if macro returns multiple slides', function () {
+      var macros = {
+        multiPage: function (times) {
+          var content = [];
+          for (var i = 0; i < times; i++) {
+            content.push(this);
+          }
+          return content.join('\n---\n');
+        }
+      };
+
+      var parsed = parser.parse('![:multiPage 5](content)', macros);
+
+      parsed.length.should.eql(5);
+      parsed.forEach(function (page) {
+        page.content.should.eql(['content']);
+      });
+    });
+
+    it('should append the first slide of multi slide macros to the current slide', function () {
+      var macros = {
+        multiPage: function (times) {
+          var content = [];
+          for (var i = 0; i < times; i++) {
+            content.push(this);
+          }
+          return content.join('\n---\n');
+        }
+      };
+
+      var parsed = parser.parse('previous ![:multiPage 5](content)', macros);
+
+      parsed.length.should.eql(5);
+      parsed[0].content.should.eql(['previous content'])
+    });
+
+    it('should not close the last slide of a multi slide macro', function () {
+      var macros = {
+        multiPage: function (times) {
+          var content = [];
+          for (var i = 0; i < times; i++) {
+            content.push(this);
+          }
+          return content.join('\n---\n');
+        }
+      };
+
+      var parsed = parser.parse('![:multiPage 5](content) after', macros);
+
+      parsed.length.should.eql(5);
+      parsed[4].content.should.eql(['content after'])
+    })
   });
 
   describe('parsing content classes', function () {


### PR DESCRIPTION
Hi!

Since I wanted to use the macros to stagger lists into slides and needed to generate multiple slides with macros as suggested in #488, I implemented the feature.

The behavior is now: When a macro is used inline and emits multiple slides, the first slide emitted is appended to the currently active slide, which is then pushed. The following slides are all pushed except the last one, which becomes the new active slide on the stack.

My reasoning for this behavior is the following scenario:

```markdown
...
---

![:stagger](
# headline

%%%
- list element
  - sub element
  - sub element
%%%
- list element
%%%
- list element
%%%
- list element
%%%
- list element
%%%
- list element
)

---
...
```

With this macro implementation:

```javascript
remark.macros.stagger = function () {
  return this.split('%%%\n').reduce(({ output, current }, part) => {
    const next = current + part
    return {
      output: output + next + '---\n',
      current: next
    }
  }, { output: '', current: '' }).output;
}
```

Looking forward to any feedback and with kind regards,
yeldiR