### PR TITLE
Add an option to exclude presenter notes

### DIFF
--- a/src/remark/models/slideshow.js
+++ b/src/remark/models/slideshow.js
@@ -219,6 +219,10 @@ function createSlides (slideshowSource, options) {
       slides.byNumber[slideNumber] = [];
     }
 
+    if (options.includePresenterNotes !== undefined && !options.includePresenterNotes) {
+      slide.notes = '';
+    }
+
     slideViewModel = new Slide(slides.length, slideNumber, slide, template);
 
     if (slide.properties.name) {


### PR DESCRIPTION
This PR adds a configuration setting that allows you to exclude presenter notes from all slides. For example:

```js
var slideshow = remark.create({
	includePresenterNotes: false,
});
```

This feature is useful if you only want to publish the slides, without the notes. By default, notes will be include if the options is not present or explicitly set to true.