### PR TITLE
Fix #532: rm `pedantic: true` from marked options

### DIFF
--- a/src/remark/converter.js
+++ b/src/remark/converter.js
@@ -8,10 +8,6 @@ marked.setOptions({
   tables: true,
   breaks: false,
 
-  // Without this set to true, converting something like
-  // <p>*</p><p>*</p> will become <p><em></p><p></em></p>
-  pedantic: true,
-
   sanitize: false,
   smartLists: true,
   langPrefix: ''


### PR DESCRIPTION
The thought here is that creating inconsistent HTML is something I can live with in exchange for GFM-support.