### PR TITLE
Fixing the issue with `count: false` on the first slide

### DIFF
--- a/src/remark/models/slideshow.js
+++ b/src/remark/models/slideshow.js
@@ -234,7 +234,9 @@ function createSlides (slideshowSource, options) {
     } else {
       if (slideIsIncluded) {
         slides.push(slideViewModel);
-        slides.byNumber[slideNumber].push(slideViewModel);
+        if (slides.byNumber[slideNumber] !== undefined) {
+          slides.byNumber[slideNumber].push(slideViewModel);
+        }
       }
       if (slide.properties.name) {
         slides.byName[slide.properties.name] = slideViewModel;

--- a/test/remark/models/slideshow_test.js
+++ b/test/remark/models/slideshow_test.js
@@ -105,6 +105,14 @@ describe('Slideshow', function () {
     });
   });
 
+  describe('non-countable slides', function() {
+    it('should not be counted if set on first slide', function() {
+      slideshow.loadFromString('count: false\n\na\n---\nb');
+      slideshow.getSlides().length.should.equal(2);
+      slideshow.getSlidesByNumber(1)[0].getSlideNumber().should.equal(1);
+    });
+  });
+
   describe('name mapping', function () {
     it('should map named slide', function () {
       slideshow.loadFromString('name: a\n---\nno name\n---\nname: b');


### PR DESCRIPTION
This issue reproed only if the first slide has `count: false` - we have a unit test that was passing when the `count:false` is not on the first slide. However, adding `count: false` to the first slide, fails the test.

Let's assume we have the following slides:

```
count:false

Slide A
---
Slide B
```

When we parse the slides we check if the slide is included (based on the classes) and if it's not a layout slide as well as if it should be counted. The code inside the if statement does not execute, so the slides.byNumber[slideNumber] is undefined

```
if (slideIsIncluded && slide.properties.layout !== 'true' && slide.properties.count !== 'false') {
      slideNumber++;
      slides.byNumber[slideNumber] = [];
}
```

Later though, we call slides.byNumber[slideNumber].push(slideViewModel); and that's what's causing the issue. 

This fix adds a check for undefined on `slides.byNumber[slideNumber]` before calling .push on it.

Resolves #613 