### PR TITLE
highlightspans: allow matching when span is first on the line

### DIFF
--- a/src/remark/views/slideView.js
+++ b/src/remark/views/slideView.js
@@ -303,7 +303,7 @@ function highlightBlockLines (block, lines) {
 function highlightBlockSpans (block, highlightSpans) {
   var pattern;
   if (highlightSpans === true) {
-    pattern = /([^`])`([^`]+?)`/g;
+    pattern = /(^|[^`])`([^`]+?)`/g;
   } else if (highlightSpans instanceof RegExp) {
     if (! highlightSpans.global) {
       throw new Error('The regular expression in `highlightSpans` must have flag /g');


### PR DESCRIPTION
This is an attempt at fixing #615, which I've also been struggling with. This modifies the regex to also allow matching the start of the line as the only thing preceding the opening backtick. This seems to fix things in my limited testing, but I've no idea whether there are any other corner cases where this might not be the right thing to do... 


As an aside, I would also suggest removing the custom padding for `remark-code-span-highlighted`([this line](https://github.com/gnab/remark/blob/develop/src/remark.less#L147)), as this causes the text to shift when displaying the same code segment across two slides when only one of them contains a code span highlight. This is easy to fix with some custom CSS, but it would be good to have this as the default behaviour.